### PR TITLE
Fix (most) Clippy lints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .vscode
 *.profraw
 coverage
+.idea

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,2 @@
+edition = "2021"
+newline_style = "Unix"

--- a/src/dialect.rs
+++ b/src/dialect.rs
@@ -9,8 +9,7 @@ pub trait Dialect {
 pub trait OperationKind: 'static {
     type Dialect: Dialect;
 
-    type Access<'rewrite, 'a, C>: OperationKindAccess<'rewrite, 'a, C, Self>
-        + AsRef<C::Operation<'rewrite, 'a>>
+    type Access<'rewrite, 'a, C>: OperationKindAccess<'rewrite, 'a, C, Self> + AsRef<C::Operation<'rewrite, 'a>>
     where
         C: 'rewrite + Context;
     type Opaque<'rewrite, C>: AsRef<C::OpaqueOperation<'rewrite>>
@@ -22,9 +21,7 @@ pub trait OperationKind: 'static {
     ///
     /// This method must check that the provided operation is indeed of the
     /// expected kind and satisfies the expectations of the operation kind.
-    fn access<'rewrite, 'a, C: Context>(
-        op: C::Operation<'rewrite, 'a>,
-    ) -> Option<Self::Access<'rewrite, 'a, C>>;
+    fn access<'rewrite, 'a, C: Context>(op: C::Operation<'rewrite, 'a>) -> Option<Self::Access<'rewrite, 'a, C>>;
 
     /// Returns true if the provided operation's structure is sufficiently valid
     /// to be accessed as this operation.
@@ -38,8 +35,7 @@ pub trait OperationKindAccess<'rewrite, 'a, C: Context, O: OperationKind + ?Size
 pub trait AttributeKind: 'static {
     type Dialect: Dialect;
 
-    type Access<'rewrite, 'a, C>: AttributeKindAccess<'rewrite, 'a, C, Self>
-        + AsRef<C::Attribute<'rewrite, 'a>>
+    type Access<'rewrite, 'a, C>: AttributeKindAccess<'rewrite, 'a, C, Self> + AsRef<C::Attribute<'rewrite, 'a>>
     where
         C: 'rewrite + Context;
     type Opaque<'rewrite, C>: AsRef<C::OpaqueAttr<'rewrite>>
@@ -51,9 +47,7 @@ pub trait AttributeKind: 'static {
     ///
     /// This method must check that the provided attribute is indeed of the
     /// expected kind and satisfies the expectations of the attribute kind.
-    fn access<'rewrite, 'a, C: Context>(
-        attr: C::Attribute<'rewrite, 'a>,
-    ) -> Option<Self::Access<'rewrite, 'a, C>>;
+    fn access<'rewrite, 'a, C: Context>(attr: C::Attribute<'rewrite, 'a>) -> Option<Self::Access<'rewrite, 'a, C>>;
 
     /// Returns true if the provided attribute's structure is sufficiently valid
     /// to be accessed as this operation.
@@ -70,17 +64,13 @@ macro_rules! declare_operation {
         pub struct $access<'rewrite, 'a, C: 'rewrite + Context>(C::Operation<'rewrite, 'a>);
         pub struct $opaque<'rewrite, C: 'rewrite + Context>(C::OpaqueOperation<'rewrite>);
 
-        impl<'rewrite, 'a, C: Context> OperationKindAccess<'rewrite, 'a, C, $name>
-            for $access<'rewrite, 'a, C>
-        {
+        impl<'rewrite, 'a, C: Context> OperationKindAccess<'rewrite, 'a, C, $name> for $access<'rewrite, 'a, C> {
             fn opaque(&self) -> $opaque<'rewrite, C> {
                 $opaque(self.0.opaque())
             }
         }
 
-        impl<'rewrite, 'a, C: Context> AsRef<C::Operation<'rewrite, 'a>>
-            for $access<'rewrite, 'a, C>
-        {
+        impl<'rewrite, 'a, C: Context> AsRef<C::Operation<'rewrite, 'a>> for $access<'rewrite, 'a, C> {
             fn as_ref(&self) -> &C::Operation<'rewrite, 'a> {
                 &self.0
             }
@@ -98,12 +88,16 @@ macro_rules! operation_defaults {
     ($dialect:ident, $access:ident, $opaque:ident) => {
         type Dialect = $dialect;
 
-        type Access<'rewrite, 'a, C> = $access<'rewrite, 'a, C> where C: 'rewrite + Context;
-        type Opaque<'rewrite, C> = $opaque<'rewrite, C> where C: 'rewrite + Context;
+        type Access<'rewrite, 'a, C>
+            = $access<'rewrite, 'a, C>
+        where
+            C: 'rewrite + Context;
+        type Opaque<'rewrite, C>
+            = $opaque<'rewrite, C>
+        where
+            C: 'rewrite + Context;
 
-        fn access<'rewrite, 'a, C: Context>(
-            op: C::Operation<'rewrite, 'a>,
-        ) -> Option<Self::Access<'rewrite, 'a, C>> {
+        fn access<'rewrite, 'a, C: Context>(op: C::Operation<'rewrite, 'a>) -> Option<Self::Access<'rewrite, 'a, C>> {
             Self::valid_access::<C>(op.clone()).then(|| $access(op))
         }
     };
@@ -115,18 +109,14 @@ macro_rules! declare_attr {
         pub struct $access<'rewrite, 'a, C: 'rewrite + Context>(C::Attribute<'rewrite, 'a>);
         pub struct $opaque<'rewrite, C: 'rewrite + Context>(C::OpaqueAttr<'rewrite>);
 
-        impl<'rewrite, 'a, C: Context> AttributeKindAccess<'rewrite, 'a, C, $name>
-            for $access<'rewrite, 'a, C>
-        {
+        impl<'rewrite, 'a, C: Context> AttributeKindAccess<'rewrite, 'a, C, $name> for $access<'rewrite, 'a, C> {
             fn opaque(&self) -> $opaque<'rewrite, C> {
                 use crate::ir::Attribute;
                 $opaque(self.0.opaque())
             }
         }
 
-        impl<'rewrite, 'a, C: Context> AsRef<C::Attribute<'rewrite, 'a>>
-            for $access<'rewrite, 'a, C>
-        {
+        impl<'rewrite, 'a, C: Context> AsRef<C::Attribute<'rewrite, 'a>> for $access<'rewrite, 'a, C> {
             fn as_ref(&self) -> &C::Attribute<'rewrite, 'a> {
                 &self.0
             }
@@ -144,12 +134,16 @@ macro_rules! attr_defaults {
     ($dialect:ident, $access:ident, $opaque:ident) => {
         type Dialect = $dialect;
 
-        type Access<'rewrite, 'a, C> = $access<'rewrite, 'a, C> where C: 'rewrite + Context;
-        type Opaque<'rewrite, C> = $opaque<'rewrite, C> where C: 'rewrite + Context;
+        type Access<'rewrite, 'a, C>
+            = $access<'rewrite, 'a, C>
+        where
+            C: 'rewrite + Context;
+        type Opaque<'rewrite, C>
+            = $opaque<'rewrite, C>
+        where
+            C: 'rewrite + Context;
 
-        fn access<'rewrite, 'a, C: Context>(
-            attr: C::Attribute<'rewrite, 'a>,
-        ) -> Option<Self::Access<'rewrite, 'a, C>> {
+        fn access<'rewrite, 'a, C: Context>(attr: C::Attribute<'rewrite, 'a>) -> Option<Self::Access<'rewrite, 'a, C>> {
             Self::valid_access::<C>(attr.clone()).then(|| $access(attr))
         }
     };

--- a/src/dialect.rs
+++ b/src/dialect.rs
@@ -25,7 +25,7 @@ pub trait OperationKind: 'static {
 
     /// Returns true if the provided operation's structure is sufficiently valid
     /// to be accessed as this operation.
-    fn valid_access<'rewrite, 'a, C: Context>(attr: C::Operation<'rewrite, 'a>) -> bool;
+    fn valid_access<C: Context>(attr: C::Operation<'_, '_>) -> bool;
 }
 
 pub trait OperationKindAccess<'rewrite, 'a, C: Context, O: OperationKind + ?Sized> {
@@ -51,7 +51,7 @@ pub trait AttributeKind: 'static {
 
     /// Returns true if the provided attribute's structure is sufficiently valid
     /// to be accessed as this operation.
-    fn valid_access<'rewrite, 'a, C: Context>(attr: C::Attribute<'rewrite, 'a>) -> bool;
+    fn valid_access<C: Context>(attr: C::Attribute<'_, '_>) -> bool;
 }
 
 pub trait AttributeKindAccess<'rewrite, 'a, C: Context, A: AttributeKind + ?Sized> {

--- a/src/dialect/builtin.rs
+++ b/src/dialect/builtin.rs
@@ -1,14 +1,11 @@
 use crate::{
-    ir::{
-        AttrData, Attribute, AttributeData, Context, OpaqueAttributeData, Operation, Region,
-        Rewriter,
-    },
+    ir::{AttrData, Attribute, AttributeData, Context, OpaqueAttributeData, Operation, Region, Rewriter},
     utils::bitbox::{BitBox, TooManyBytesError},
 };
 
 use super::{
-    attr_defaults, declare_attr, declare_operation, operation_defaults, AttributeKind, Dialect,
-    OperationKind, OperationKindAccess,
+    attr_defaults, declare_attr, declare_operation, operation_defaults, AttributeKind, Dialect, OperationKind,
+    OperationKindAccess,
 };
 use crate::dialect::AttributeKindAccess;
 pub struct BuiltinDialect;
@@ -79,8 +76,7 @@ impl StringAttr {
         rewriter: &C::Rewriter<'rewrite>,
         data: &[u8],
     ) -> Result<C::OpaqueAttr<'rewrite>, TooManyBytesError> {
-        Ok(rewriter
-            .create_attribute::<StringAttr>(OpaqueAttributeData::Bits(BitBox::from_bytes(data)?)))
+        Ok(rewriter.create_attribute::<StringAttr>(OpaqueAttributeData::Bits(BitBox::from_bytes(data)?)))
     }
 }
 

--- a/src/dialect/builtin.rs
+++ b/src/dialect/builtin.rs
@@ -27,7 +27,7 @@ declare_operation!(ModuleOp, ModuleOpAccess, ModuleOpOpaque);
 impl OperationKind for ModuleOp {
     operation_defaults!(BuiltinDialect, ModuleOpAccess, ModuleOpOpaque);
 
-    fn valid_access<'rewrite, 'a, C: Context>(op: C::Operation<'rewrite, 'a>) -> bool {
+    fn valid_access<C: Context>(op: C::Operation<'_, '_>) -> bool {
         op.isa::<ModuleOp>() && op.get_region(0).and_then(|r| r.get_block(0)).is_some()
     }
 }
@@ -62,7 +62,7 @@ declare_attr!(StringAttr, StringAttrAccess, StringAttrOpaque);
 impl AttributeKind for StringAttr {
     attr_defaults!(BuiltinDialect, StringAttrAccess, StringAttrOpaque);
 
-    fn valid_access<'rewrite, 'a, C: Context>(attr: C::Attribute<'rewrite, 'a>) -> bool {
+    fn valid_access<C: Context>(attr: C::Attribute<'_, '_>) -> bool {
         attr.isa::<StringAttr>()
             && match attr.data() {
                 AttributeData::Bits(bits) => bits.len() % 8 == 0,
@@ -80,8 +80,8 @@ impl StringAttr {
     }
 }
 
-impl<'rewrite, 'a, C: Context + 'a> StringAttrAccess<'rewrite, 'a, C> {
-    pub fn as_bytes<'data>(&'data self) -> impl AttrData<'data, [u8]> {
+impl<'a, C: Context + 'a> StringAttrAccess<'_, 'a, C> {
+    pub fn as_bytes(&self) -> impl AttrData<'_, [u8]> {
         let AttributeData::Bits(bits) = self.as_ref().data() else {
             unreachable!("verified")
         };

--- a/src/ir.rs
+++ b/src/ir.rs
@@ -3,7 +3,7 @@ mod gc;
 #[cfg(feature = "gc")]
 pub use gc::GcContext;
 
-use ariadne::{Report, ReportBuilder, ReportKind};
+use ariadne::ReportBuilder;
 
 use std::ops::{Deref, Range};
 
@@ -78,7 +78,7 @@ pub trait Context: Sized {
     fn register_attribute<A: AttributeKind>(&mut self);
 
     /// Creates a program containing an empty module operation.
-    fn module_program<'ctx>(&'ctx self) -> Self::Program<'ctx>;
+    fn module_program(&self) -> Self::Program<'_>;
 
     /// Applies the provided pattern to the top level operation of the provided program.
     fn apply_pattern<'ctx, P: RewritePattern<Self>>(

--- a/src/ir.rs
+++ b/src/ir.rs
@@ -171,33 +171,17 @@ pub trait Rewriter<'rewrite, C: Context> {
 
     /// Inserts an operation in the same block of an other operation,
     /// before it. The other operation must already be inserted in a block.
-    fn insert_op_before(
-        &self,
-        op: C::OpaqueOperation<'rewrite>,
-        other: C::OpaqueOperation<'rewrite>,
-    );
+    fn insert_op_before(&self, op: C::OpaqueOperation<'rewrite>, other: C::OpaqueOperation<'rewrite>);
 
     /// Inserts an operation in the same block of an other operation,
     /// after it. The other operation must already be inserted in a block.
-    fn insert_op_after(
-        &self,
-        op: C::OpaqueOperation<'rewrite>,
-        other: C::OpaqueOperation<'rewrite>,
-    );
+    fn insert_op_after(&self, op: C::OpaqueOperation<'rewrite>, other: C::OpaqueOperation<'rewrite>);
 
     /// Inserts an operation at the start of a block.
-    fn insert_op_at_start(
-        &self,
-        op: C::OpaqueOperation<'rewrite>,
-        at_start_of: C::OpaqueBlock<'rewrite>,
-    );
+    fn insert_op_at_start(&self, op: C::OpaqueOperation<'rewrite>, at_start_of: C::OpaqueBlock<'rewrite>);
 
     /// Inserts an operation at the end of a block.
-    fn insert_op_at_end(
-        &self,
-        op: C::OpaqueOperation<'rewrite>,
-        at_end_of: C::OpaqueBlock<'rewrite>,
-    );
+    fn insert_op_at_end(&self, op: C::OpaqueOperation<'rewrite>, at_end_of: C::OpaqueBlock<'rewrite>);
 
     /// Creates a free standing operation.
     fn create_op<O: OperationKind>(
@@ -224,12 +208,7 @@ pub trait Rewriter<'rewrite, C: Context> {
     fn create_region(&self, blocks: &[C::OpaqueBlock<'rewrite>]) -> C::OpaqueRegion<'rewrite>;
 
     /// Inserts or replace an attribute in the operation's dictionary.
-    fn set_attribute(
-        &self,
-        op: C::OpaqueOperation<'rewrite>,
-        attr_name: &str,
-        attr: C::OpaqueAttr<'rewrite>,
-    );
+    fn set_attribute(&self, op: C::OpaqueOperation<'rewrite>, attr_name: &str, attr: C::OpaqueAttr<'rewrite>);
 
     /// Sets an existing operand of an operation to be a specific value.
     fn set_operand(

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -11,10 +11,7 @@ use thiserror::Error;
 
 use crate::{
     dialect::builtin::ModuleOp,
-    ir::{
-        Accessor, Context, Operation, PatternResult, RewritePattern, Rewriter,
-        SingleUseRewritePattern,
-    },
+    ir::{Accessor, Context, Operation, PatternResult, RewritePattern, Rewriter, SingleUseRewritePattern},
     utils::u8_to_ascii_or_value,
 };
 
@@ -98,9 +95,7 @@ impl<'rewriter, 'parsing, 'src, C: Context> Parser<'rewriter, 'parsing, 'src, C>
         }
     }
 
-    pub fn register_ssa_value() {
-        
-    }
+    pub fn register_ssa_value() {}
 
     pub fn parse_opt_keyword(&mut self, keyword: impl AsRef<[u8]>) -> ParseResult<Option<()>> {
         todo!()
@@ -190,7 +185,6 @@ impl<'rewriter, 'parsing, 'src, C: Context> Parser<'rewriter, 'parsing, 'src, C>
             return Ok(result);
         }
 
-
         result.push(parser(self)?);
         while self.parse_opt_punctuation(separator)?.is_some() {
             result.push(parser(self)?);
@@ -201,9 +195,8 @@ impl<'rewriter, 'parsing, 'src, C: Context> Parser<'rewriter, 'parsing, 'src, C>
     }
 
     pub fn parse_punctuation(&mut self, punctuation: Punctuation) -> ParseResult<()> {
-        self.parse_opt_punctuation(punctuation).and_then(|x| {
-            x.ok_or_else(|| self.diagnostic_here(format!("expected '{}'", punctuation.as_str())))
-        })
+        self.parse_opt_punctuation(punctuation)
+            .and_then(|x| x.ok_or_else(|| self.diagnostic_here(format!("expected '{}'", punctuation.as_str()))))
     }
 
     pub fn parse_opt_punctuation(&mut self, punctuation: Punctuation) -> ParseResult<Option<()>> {
@@ -219,10 +212,7 @@ impl<'rewriter, 'parsing, 'src, C: Context> Parser<'rewriter, 'parsing, 'src, C>
     }
 
     /// Parses a sequence of elements accepted by the provided parser, until None or an error is returned.
-    pub fn parse_many<T>(
-        &mut self,
-        f: impl Fn(&mut Self) -> ParseResult<Option<T>>,
-    ) -> ParseResult<Vec<T>> {
+    pub fn parse_many<T>(&mut self, f: impl Fn(&mut Self) -> ParseResult<Option<T>>) -> ParseResult<Vec<T>> {
         let mut result = Vec::new();
         while let Some(x) = f(self)? {
             result.push(x);

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,17 +1,9 @@
-use std::{
-    arch::x86_64,
-    borrow::Borrow,
-    io::Read,
-    marker::PhantomData,
-    ops::{Deref, DerefMut},
-};
 
 use lexer::{Lexer, LexerError, LexicalSpan, Punctuation, Token, TokenKind};
-use thiserror::Error;
 
 use crate::{
     dialect::builtin::ModuleOp,
-    ir::{Accessor, Context, Operation, PatternResult, RewritePattern, Rewriter, SingleUseRewritePattern},
+    ir::{Accessor, Context, Operation, PatternResult, Rewriter, SingleUseRewritePattern},
     utils::u8_to_ascii_or_value,
 };
 

--- a/src/parser/lexer.rs
+++ b/src/parser/lexer.rs
@@ -1,10 +1,4 @@
-use std::{
-    error::Error,
-    fmt,
-    io::{Bytes, Read},
-    marker::PhantomData,
-    ops::Deref,
-};
+use std::fmt;
 
 use thiserror::Error;
 
@@ -342,7 +336,13 @@ impl<'src> Lexer<'src> {
                 + 2
                 + self.source[(self.next_position + 2)..]
                     .iter()
-                    .take_while(|&&x| x.is_ascii_alphanumeric() || x == b'.' || x == b'_' || x == b'$' || x == b'-')
+                    .take_while(|&&x| {
+                        x.is_ascii_alphanumeric()
+                            || x == b'.'
+                            || x == b'_'
+                            || x == b'$'
+                            || x == b'-'
+                    })
                     .count()
         } else {
             return Err(LexerError::ExpectedSuffixIdentifier(self.next_position + 1));
@@ -401,7 +401,11 @@ impl<'src> Lexer<'src> {
             Some(b'?') => Ok(Some(self.lex_punctuation(Punctuation::Question))),
             Some(b'|') => Ok(Some(self.lex_punctuation(Punctuation::VerticalBar))),
             Some(b'.') => {
-                if self.source.get(self.next_position + 1..self.next_position + 3) == Some(b"..") {
+                if self
+                    .source
+                    .get(self.next_position + 1..self.next_position + 3)
+                    == Some(b"..")
+                {
                     // Lexing: ...
                     Ok(Some(self.lex_punctuation(Punctuation::Ellipsis)))
                 } else {
@@ -418,7 +422,11 @@ impl<'src> Lexer<'src> {
                 }
             }
             Some(b'{') => {
-                if self.source.get(self.next_position + 1..self.next_position + 3) == Some(b"-#") {
+                if self
+                    .source
+                    .get(self.next_position + 1..self.next_position + 3)
+                    == Some(b"-#")
+                {
                     // Lexing: {-#
                     Ok(Some(self.lex_punctuation(Punctuation::FileMetadataBegin)))
                 } else {
@@ -427,17 +435,28 @@ impl<'src> Lexer<'src> {
                 }
             }
             Some(b'#') => {
-                if self.source.get(self.next_position + 1..self.next_position + 3) == Some(b"-}") {
+                if self
+                    .source
+                    .get(self.next_position + 1..self.next_position + 3)
+                    == Some(b"-}")
+                {
                     // Lexing: #-}
                     Ok(Some(self.lex_punctuation(Punctuation::FileMetadataEnd)))
                 } else {
                     // Lexing: hash-ident
-                    self.lex_prefixed_identifier(TokenKind::HashIdentifier).map(Some)
+                    self.lex_prefixed_identifier(TokenKind::HashIdentifier)
+                        .map(Some)
                 }
             }
-            Some(b'!') => self.lex_prefixed_identifier(TokenKind::ExclamationIdentifier).map(Some),
-            Some(b'^') => self.lex_prefixed_identifier(TokenKind::CaretIdentifier).map(Some),
-            Some(b'%') => self.lex_prefixed_identifier(TokenKind::PercentIdentifier).map(Some),
+            Some(b'!') => self
+                .lex_prefixed_identifier(TokenKind::ExclamationIdentifier)
+                .map(Some),
+            Some(b'^') => self
+                .lex_prefixed_identifier(TokenKind::CaretIdentifier)
+                .map(Some),
+            Some(b'%') => self
+                .lex_prefixed_identifier(TokenKind::PercentIdentifier)
+                .map(Some),
             Some(b'@') => self.lex_symbol().map(Some),
             Some(b'"') => self.lex_string_literal().map(Some),
             Some(c) if c.is_ascii_digit() => self.lex_number().map(Some),

--- a/src/parser/lexer.rs
+++ b/src/parser/lexer.rs
@@ -342,13 +342,7 @@ impl<'src> Lexer<'src> {
                 + 2
                 + self.source[(self.next_position + 2)..]
                     .iter()
-                    .take_while(|&&x| {
-                        x.is_ascii_alphanumeric()
-                            || x == b'.'
-                            || x == b'_'
-                            || x == b'$'
-                            || x == b'-'
-                    })
+                    .take_while(|&&x| x.is_ascii_alphanumeric() || x == b'.' || x == b'_' || x == b'$' || x == b'-')
                     .count()
         } else {
             return Err(LexerError::ExpectedSuffixIdentifier(self.next_position + 1));
@@ -407,11 +401,7 @@ impl<'src> Lexer<'src> {
             Some(b'?') => Ok(Some(self.lex_punctuation(Punctuation::Question))),
             Some(b'|') => Ok(Some(self.lex_punctuation(Punctuation::VerticalBar))),
             Some(b'.') => {
-                if self
-                    .source
-                    .get(self.next_position + 1..self.next_position + 3)
-                    == Some(b"..")
-                {
+                if self.source.get(self.next_position + 1..self.next_position + 3) == Some(b"..") {
                     // Lexing: ...
                     Ok(Some(self.lex_punctuation(Punctuation::Ellipsis)))
                 } else {
@@ -428,11 +418,7 @@ impl<'src> Lexer<'src> {
                 }
             }
             Some(b'{') => {
-                if self
-                    .source
-                    .get(self.next_position + 1..self.next_position + 3)
-                    == Some(b"-#")
-                {
+                if self.source.get(self.next_position + 1..self.next_position + 3) == Some(b"-#") {
                     // Lexing: {-#
                     Ok(Some(self.lex_punctuation(Punctuation::FileMetadataBegin)))
                 } else {
@@ -441,28 +427,17 @@ impl<'src> Lexer<'src> {
                 }
             }
             Some(b'#') => {
-                if self
-                    .source
-                    .get(self.next_position + 1..self.next_position + 3)
-                    == Some(b"-}")
-                {
+                if self.source.get(self.next_position + 1..self.next_position + 3) == Some(b"-}") {
                     // Lexing: #-}
                     Ok(Some(self.lex_punctuation(Punctuation::FileMetadataEnd)))
                 } else {
                     // Lexing: hash-ident
-                    self.lex_prefixed_identifier(TokenKind::HashIdentifier)
-                        .map(Some)
+                    self.lex_prefixed_identifier(TokenKind::HashIdentifier).map(Some)
                 }
             }
-            Some(b'!') => self
-                .lex_prefixed_identifier(TokenKind::ExclamationIdentifier)
-                .map(Some),
-            Some(b'^') => self
-                .lex_prefixed_identifier(TokenKind::CaretIdentifier)
-                .map(Some),
-            Some(b'%') => self
-                .lex_prefixed_identifier(TokenKind::PercentIdentifier)
-                .map(Some),
+            Some(b'!') => self.lex_prefixed_identifier(TokenKind::ExclamationIdentifier).map(Some),
+            Some(b'^') => self.lex_prefixed_identifier(TokenKind::CaretIdentifier).map(Some),
+            Some(b'%') => self.lex_prefixed_identifier(TokenKind::PercentIdentifier).map(Some),
             Some(b'@') => self.lex_symbol().map(Some),
             Some(b'"') => self.lex_string_literal().map(Some),
             Some(c) if c.is_ascii_digit() => self.lex_number().map(Some),

--- a/src/utils/bitbox.rs
+++ b/src/utils/bitbox.rs
@@ -97,6 +97,8 @@ impl BitBox {
     pub fn len(&self) -> usize {
         self.len
     }
+    
+    pub fn is_empty(&self) -> bool { self.len == 0 }
 
     pub fn as_bytes(&self) -> Option<&[u8]> {
         (self.len % 8 == 0).then(|| match &self.data {

--- a/src/utils/bitbox.rs
+++ b/src/utils/bitbox.rs
@@ -3,7 +3,7 @@ use std::mem::size_of;
 use thiserror::Error;
 
 /// Amount of bits from which data should be stored offline (inclusive), in bits.
-const BITBOX_OFFLINE_THRESHOLD: usize = size_of::<usize>() * 8;
+const BITBOX_OFFLINE_THRESHOLD: usize = usize::BITS as usize;
 
 #[cfg_attr(feature = "gc", derive(dumpster::Collectable))]
 #[derive(PartialEq, Eq, Debug)]
@@ -77,7 +77,7 @@ impl BitBox {
 
         (id < self.len).then(|| match &self.data {
             Inline(data) => get_bit(*data, id),
-            Offline(data) => get_bit(data[id / (size_of::<usize>() * 8)], id % (size_of::<usize>() * 8)),
+            Offline(data) => get_bit(data[id / usize::BITS as usize], id % usize::BITS as usize),
         })
     }
 

--- a/src/utils/bitbox.rs
+++ b/src/utils/bitbox.rs
@@ -63,12 +63,7 @@ impl BitBox {
             len: bytes.len() * 8,
             data: match bytes.len() <= BITBOX_OFFLINE_THRESHOLD / 8 {
                 true => Inline(bytes_to_usize(bytes)),
-                false => Offline(
-                    bytes
-                        .chunks(size_of::<usize>())
-                        .map(bytes_to_usize)
-                        .collect(),
-                ),
+                false => Offline(bytes.chunks(size_of::<usize>()).map(bytes_to_usize).collect()),
             },
         })
     }
@@ -76,19 +71,13 @@ impl BitBox {
     pub fn get(&self, id: usize) -> Option<bool> {
         #[inline(always)]
         fn get_bit(data: usize, id: usize) -> bool {
-            eprintln!(
-                "data: {data:x}, id: {id}, res: {}",
-                data.to_le() & (1 << id)
-            );
+            eprintln!("data: {data:x}, id: {id}, res: {}", data.to_le() & (1 << id));
             data.to_le() & (1 << id) != 0
         }
 
         (id < self.len).then(|| match &self.data {
             Inline(data) => get_bit(*data, id),
-            Offline(data) => get_bit(
-                data[id / (size_of::<usize>() * 8)],
-                id % (size_of::<usize>() * 8),
-            ),
+            Offline(data) => get_bit(data[id / (size_of::<usize>() * 8)], id % (size_of::<usize>() * 8)),
         })
     }
 
@@ -111,9 +100,7 @@ impl BitBox {
 
     pub fn as_bytes(&self) -> Option<&[u8]> {
         (self.len % 8 == 0).then(|| match &self.data {
-            Inline(data) => {
-                &bytemuck::must_cast_ref::<usize, [u8; size_of::<usize>()]>(data)[..(self.len / 8)]
-            }
+            Inline(data) => &bytemuck::must_cast_ref::<usize, [u8; size_of::<usize>()]>(data)[..(self.len / 8)],
             Offline(data) => &bytemuck::must_cast_slice::<usize, u8>(data)[..(self.len / 8)],
         })
     }
@@ -139,12 +126,7 @@ mod tests {
         assert_eq!(BitBox::from_bytes(&[]), Ok(BitBox::empty()));
     }
 
-    fn bytes(
-        bytes: &[u8],
-        bit_tests: &[(usize, Option<bool>)],
-        byte_tests: &[(usize, Option<u8>)],
-        is_inline: bool,
-    ) {
+    fn bytes(bytes: &[u8], bit_tests: &[(usize, Option<bool>)], byte_tests: &[(usize, Option<u8>)], is_inline: bool) {
         let bbox: BitBox = BitBox::from_bytes(bytes).unwrap();
         assert_eq!(bbox.len(), bytes.len() * 8);
         assert_eq!(bbox.as_bytes(), Some(bytes));


### PR DESCRIPTION
Applied `cargo clippy --fix` and a manual fix to `BitBox`.

The "unused stuff" lints are left for the parser since it's WIP.